### PR TITLE
Allow regular and faster urls list reload for more dynamic scenarios

### DIFF
--- a/background.html
+++ b/background.html
@@ -3,4 +3,5 @@ Tabulus Rotatum
 
 Created by Cami Blanch
 -->
+<script src="src/urlslist.js"></script>
 <script src="src/background.js"></script>

--- a/options.html
+++ b/options.html
@@ -123,6 +123,14 @@
     <p>
         <label for="autoloadurls">Auto Load URLs from URL:</label>
         <input type="checkbox" name="autoloadurls" id="autoloadurls">
+
+        <label for="refreshList">Reload</label>
+        <select name="refreshList" id="refreshList">
+            <option value="">only on browser start</option>
+            <option value="afterTabCycle">after each tab cycle</option>
+            <option value="afterEachTab">after each tab switch</option>
+        </select>
+
         <span class="example">Automatically load URLs from a text file hosted in a URL on the web.</span>
         <span id="loadoptions">
             <br>

--- a/options.html
+++ b/options.html
@@ -160,6 +160,7 @@
 
 </body>
 
+<script src="src/urlslist.js"></script>
 <script src="src/options.js"></script>
 
 </html>

--- a/src/background.js
+++ b/src/background.js
@@ -12,6 +12,7 @@ var paused = false;
 var firstPause = true;
 var firstPlay = true;
 
+// Bug? Looks like the values here are cached on .js file load and keep stale until browser restart
 var tabAutostart = false;
 if (localStorage.autostart) {
   tabAutostart = (localStorage.autostart == 'true');
@@ -20,7 +21,6 @@ var waitTime = 0;
 if (localStorage.waittime) {
   waitTime = localStorage.waittime;
 }
-
 var urls = [];
 if (localStorage.urls) {
   urls = JSON.parse(localStorage.urls);
@@ -28,6 +28,9 @@ if (localStorage.urls) {
 var urlsIntervals = [];
 if (localStorage.urlsIntervals) {
   urlsIntervals = JSON.parse(localStorage.urlsIntervals);
+}
+if (localStorage.autoloadurls) {
+  reload_urls();
 }
 
 var urlsIndex = 0;
@@ -105,6 +108,22 @@ function badgeTabs(text) {
   }
 }
 
+// Loads the URLs and intervals from text loaded from a URL
+function reload_urls() {
+  console.log("URL LIST: reloading");
+  var xmlhttp = new XMLHttpRequest();
+  var url = localStorage.loadurl;
+  if (url !== "") {
+    xmlhttp.onreadystatechange = function () {
+      if (xmlhttp.readyState == 4) {
+        saveUrlsAndIntervalsFromString(xmlhttp.responseText);
+      }
+    };
+    xmlhttp.open("GET", url, true);
+    xmlhttp.send(null);
+  }
+}
+
 // Start on a specific window
 function go(windowId) {
   clearInterval(pauseInterval[0]);
@@ -172,8 +191,16 @@ function moveTab() {
     selected: false
   });
   urlsIndex++;
+  var refreshList = localStorage.refreshList; // load it here and not at the beginning of file
+  // to get current value
+  if (refreshList == "afterEachTab") {
+    reload_urls();
+  }
   if (urlsIndex == urls.length) {
     urlsIndex = 0;
+    if (refreshList == "afterTabCycle") {
+      reload_urls();
+    }
   }
   clearInterval(moverInterval);
 }

--- a/src/dom.js
+++ b/src/dom.js
@@ -3,5 +3,5 @@ var i = 0;
 document.onmousemove = function () {
   chrome.runtime.sendMessage({movement: "MOUSEMOVED"});
 
-  console.log(++i);
+  // console.log(++i);
 };

--- a/src/options.js
+++ b/src/options.js
@@ -11,6 +11,7 @@ function save_options() {
   }
 
   localStorage.waittime = document.getElementById("waittime").value;
+  localStorage.refreshList = document.getElementById("refreshList").value;
   bg.waitTime = localStorage.waittime;
 
   localStorage.loadurl = document.getElementById("loadurl").value;
@@ -59,6 +60,16 @@ function restore_options() {
       }
     }
   }
+  if (localStorage.refreshList) {
+    dropDown = document.getElementById("refreshList");
+    for (var i = 0; i < dropDown.options.length; i++) {
+      if (dropDown.options[i].value === localStorage.refreshList) {
+        dropDown.selectedIndex = i;
+        break;
+      }
+    }
+  }
+
   if (localStorage.loadurl) {
     document.getElementById("loadurl").value = localStorage.loadurl;
   }

--- a/src/options.js
+++ b/src/options.js
@@ -113,52 +113,8 @@ function load_urls() {
 }
 
 function saveUrlsAndIntervals() {
-  var line = document.getElementById('urls').value.split('\n');
-  var urlsArray = [];
-  var urlsIntervalsArray = [];
-
-  bg.urls = [];
-  bg.urlsIntervals = [];
-  var badLine = [];
-
-  for (var i = 0; i < line.length; i++) {
-    if (line[i] != "") {
-      if (line[i].indexOf(";") < 0) {
-        badLine.push(i);
-        console.log("Missing ;\nLine " + i + " ignored.");
-      } else {
-        var urlAndIndex = line[i].split(';');
-        if (urlAndIndex.length > 2) {
-          badLine.push(i);
-          console.log("Too many ';'\nLine " + i + " ignored");
-        } else if (urlAndIndex[0] == "" && urlAndIndex[1] == "") {
-          badLine.push(i);
-          console.log("Missing url and/or time interval.\nLine " + i + " ignored.");
-        } else if (isNaN(urlAndIndex[0])) {
-          badLine.push(i);
-          console.log("Time interval is not a number.\nLine " + i + " ignored.");
-        } else {
-          urlsArray.push(urlAndIndex[1]);
-          urlsIntervalsArray.push(urlAndIndex[0]);
-
-          bg.urls.push(urlAndIndex[1]);
-          bg.urlsIntervals.push(urlAndIndex[0]);
-        }
-      }
-    }
-  }
-  for (i = badLine.length - 1; i >= 0; i--) {
-    line.splice(badLine[i], 1);
-  }
-
-  var urlsAndInterals = "";
-
-  for (i = 0; i < line.length; i++) {
-    urlsAndInterals = urlsAndInterals + line[i] + "\n";
-  }
-  document.getElementById('urls').value = urlsAndInterals;
-  localStorage.urls = JSON.stringify(urlsArray);
-  localStorage.urlsIntervals = JSON.stringify(urlsIntervalsArray);
+  document.getElementById('urls').value =
+    saveUrlsAndIntervalsFromString(document.getElementById('urls').value);
 }
 
 // Adding listeners for restoring and saving options

--- a/src/urlslist.js
+++ b/src/urlslist.js
@@ -1,0 +1,51 @@
+function saveUrlsAndIntervalsFromString(s) {
+  var line = s.split('\n');
+  var urlsArray = [];
+  var urlsIntervalsArray = [];
+
+  var bg = chrome.extension.getBackgroundPage();
+
+  bg.urls = [];
+  bg.urlsIntervals = [];
+  var badLine = [];
+
+  for (var i = 0; i < line.length; i++) {
+    if (line[i] != "") {
+      if (line[i].indexOf(";") < 0) {
+        badLine.push(i);
+        console.log("Missing ;\nLine " + i + " ignored.");
+      } else {
+        var urlAndIndex = line[i].split(';');
+        if (urlAndIndex.length > 2) {
+          badLine.push(i);
+          console.log("Too many ';'\nLine " + i + " ignored");
+        } else if (urlAndIndex[0] == "" && urlAndIndex[1] == "") {
+          badLine.push(i);
+          console.log("Missing url and/or time interval.\nLine " + i + " ignored.");
+        } else if (isNaN(urlAndIndex[0])) {
+          badLine.push(i);
+          console.log("Time interval is not a number.\nLine " + i + " ignored.");
+        } else {
+          urlsArray.push(urlAndIndex[1]);
+          urlsIntervalsArray.push(urlAndIndex[0]);
+
+          bg.urls.push(urlAndIndex[1]);
+          bg.urlsIntervals.push(urlAndIndex[0]);
+        }
+      }
+    }
+  }
+  for (i = badLine.length - 1; i >= 0; i--) {
+    line.splice(badLine[i], 1);
+  }
+
+  var urlsAndInterals = "";
+
+  for (i = 0; i < line.length; i++) {
+    urlsAndInterals = urlsAndInterals + line[i] + "\n";
+  }
+  localStorage.urls = JSON.stringify(urlsArray);
+  localStorage.urlsIntervals = JSON.stringify(urlsIntervalsArray);
+  return urlsAndInterals;
+}
+


### PR DESCRIPTION
To enable different tab sets depending on time of the day or certain conditions,
it is not enough to load url list from the options page. We can give the user
possibility to reload the url list after each tab cycle or even more frequently -
after switching each tab.

Example at work: systems monitoring. Tabs show status of different subsystems.
But if there is an error condition - reduce the tab set and only show the affected systems.

Example at home: in the morning hours show the weather forecast, traffic conditions, news.
In the evening: show random photo, recipe of the day, tv guide.

I am using a tiny sinatra http://sinatrarb.com based web application to implement the logic
for the url lists.
